### PR TITLE
Changed protocol to HTTPS for accessing assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
 		<link rel="author" href="https://plus.google.com/+VardanGrigoryan" />
 
 		<!-- Attaching Google Fonts -->
-		<link href='http://fonts.googleapis.com/css?family=Lato:300italic,400italic,600italic,700italic,800italic,400,800,700,600,300' rel='stylesheet' type='text/css'>
-		<link href='http://fonts.googleapis.com/css?family=Roboto:300,700,400' rel='stylesheet' type='text/css'>
+		<link href='https://fonts.googleapis.com/css?family=Lato:300italic,400italic,600italic,700italic,800italic,400,800,700,600,300' rel='stylesheet' type='text/css'>
+		<link href='https://fonts.googleapis.com/css?family=Roboto:300,700,400' rel='stylesheet' type='text/css'>
 
 		<!-- Attaching Css -->
 		<link rel="stylesheet" href="css/bootstrap.min.css" />
@@ -428,7 +428,7 @@
 		</div> <!-- end main-wrapper -->
 		
 		<!-- jQuery Scripts -->
-		<script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 		<script type="text/javascript" src="js/canvas-vas.js"></script>
 		<script type="text/javascript" src="js/bootstrap.min.js"></script>
 		<script type="text/javascript" src="js/lightbox.min.js"></script>
@@ -440,7 +440,7 @@
 		<script type="text/javascript" src="js/jquery.simple-text-rotator.min.js"></script>
 		<script type="text/javascript" src="js/jquery.easing.min.js"></script>
 		<script type="text/javascript" src="js/wow.min.js"></script>
-		<script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=false"></script>
+		<script type="text/javascript" src="https://maps.google.com/maps/api/js?sensor=false"></script>
 		<script type="text/javascript" src="js/jquery.gmap.js"></script>
 	    <script type="text/javascript" src="js/scripts.js"></script>
 

--- a/single.html
+++ b/single.html
@@ -10,8 +10,8 @@
 		<link rel="author" href="https://plus.google.com/u/0/104296509460513856975" />
 		
 		<!-- Attaching Google Fonts -->
-		<link href='http://fonts.googleapis.com/css?family=Lato:300italic,400italic,600italic,700italic,800italic,400,800,700,600,300' rel='stylesheet' type='text/css'>
-		<link href='http://fonts.googleapis.com/css?family=Roboto:300,700,400' rel='stylesheet' type='text/css'>
+		<link href='https://fonts.googleapis.com/css?family=Lato:300italic,400italic,600italic,700italic,800italic,400,800,700,600,300' rel='stylesheet' type='text/css'>
+		<link href='https://fonts.googleapis.com/css?family=Roboto:300,700,400' rel='stylesheet' type='text/css'>
 
 		<!-- Attaching Css -->
 		<link rel="stylesheet" href="css/bootstrap.min.css" />
@@ -211,7 +211,7 @@
 		</div> <!-- end main-wrapper -->
 		
 		<!-- jQuery Scripts -->
-		<script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 		<script type="text/javascript" src="js/canvas-vas.js"></script>
 		<script type="text/javascript" src="js/bootstrap.min.js"></script>
 		<script type="text/javascript" src="js/lightbox.min.js"></script>
@@ -223,7 +223,7 @@
 		<script type="text/javascript" src="js/jquery.simple-text-rotator.min.js"></script>
 		<script type="text/javascript" src="js/jquery.easing.min.js"></script>
 		<script type="text/javascript" src="js/wow.min.js"></script>
-		<script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=false"></script>
+		<script type="text/javascript" src="https://maps.google.com/maps/api/js?sensor=false"></script>
 		<script type="text/javascript" src="js/jquery.gmap.js"></script>
 	    <script type="text/javascript" src="js/scripts.js"></script>
 


### PR DESCRIPTION
Acessing the generated site via HTTPS means that the fonts and JavaScript being accessed from a CDN do not load and the page throws errors.

Taken from [http://www.paulirish.com/2010/the-protocol-relative-url/](http://www.paulirish.com/2010/the-protocol-relative-url/)

> Now that SSL is encouraged for everyone and doesn’t have performance concerns, this technique is now an anti-pattern. If the asset you need is available on SSL, then always use the https:// asset.
> 
> Allowing the snippet to request over HTTP opens the door for attacks like the recent Github Man-on-the-side attack. It’s always safe to request HTTPS assets even if your site is on HTTP, however the reverse is not true.
